### PR TITLE
Add multiple stock Samsung apps

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -2585,6 +2585,18 @@ packages:
             issue: 929
             apk:
               sha256: 5a48ea197d8da4c72b43ad45d8b28bb4c5806ec81cadaa18b580622ad4d881d6
+  - package: com.samsung.android.app.notes
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 977
+  - package: com.samsung.android.app.reminder
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 938
   - package: com.samsung.android.app.spage
     signature:
       - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
@@ -2609,6 +2621,24 @@ packages:
             issue: 925
             apk:
               sha256: acb94bec97629dccf0a66dad8fb701867cb89cdf1d73e728f63facbd33fee4ff
+  - package: com.samsung.android.bixby.ondevice.enus
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 966
+  - package: com.samsung.android.bixby.ondevice.esus
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 967
+  - package: com.samsung.android.calendar
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 911
   - package: com.samsung.android.game.gamehome
     signature:
       - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
@@ -2617,6 +2647,12 @@ packages:
             issue: 923
             apk:
               sha256: 2d6cc2b6931c08f72fff9f69d0bfa068709e044de3cf3e34069e2f0db399657a
+  - package: com.samsung.android.nmt.apps.t2t.languagepack.enesus
+    signature:
+      - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42
+        sources:
+          - name: Custom (Samsung)
+            issue: 935
   - package: com.samsung.android.oneconnect
     signature:
       - fingerprint: 34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42


### PR DESCRIPTION
On the basis that these signatures match other well-known Samsung signatures already in the database, all match `34:DF:0E:7A:9F:1C:F1:89:2E:45:C0:56:B4:97:3C:D8:1C:CF:14:8A:40:50:D1:1A:EA:4A:C5:A6:5F:90:0A:42`

Closes #977 
Closes #938 
Closes #966 
Closes #967 
Closes #911 
Closes #935 